### PR TITLE
chore(envs): add cache-related envs to example file

### DIFF
--- a/apps/grammar-trainer-api/.env.example
+++ b/apps/grammar-trainer-api/.env.example
@@ -8,7 +8,12 @@ NODE_ENV=development
 HOST=localhost
 PORT=3000
 
+# Cache
+CACHE_HOST=localhost
+CACHE_PORT=6379
+
 # Sessions
 SESSION_SECRET=changeme # Replace with a strong, unique secret
+SESSION_MAX_AGE=300000
 SESSION_RESAVE=false
 SESSION_SAVE_UNINITIALIZED=false


### PR DESCRIPTION
- Added example values to .env.example file for all cache-related environment variables.
- Also added an example value for SESSION_MAX_AGE environment variable.