### PR TITLE
docs(envs): add db-related envs to example file

### DIFF
--- a/apps/grammar-trainer-api/.env.example
+++ b/apps/grammar-trainer-api/.env.example
@@ -8,6 +8,17 @@ NODE_ENV=development
 HOST=localhost
 PORT=3000
 
+# PostgreSQL Database
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=development
+DB_USER=postgres
+DB_PASSWORD=changeme
+
+# Connection string for prisma client to use when connecting to database at runtime
+# This value should be in sync with same variable in prisma/.env file
+DATABASE_URL=postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?schema=public
+
 # Cache
 CACHE_HOST=localhost
 CACHE_PORT=6379

--- a/apps/grammar-trainer-api/prisma/.env.example
+++ b/apps/grammar-trainer-api/prisma/.env.example
@@ -1,0 +1,3 @@
+# Connection string for prisma migrate and generate commands to use (not app at runtime)
+# This value should be in sync with same variable in .env.development file
+DATABASE_URL=postgres://USER:PASSWORD@HOST:PORT/NAME?schema=public


### PR DESCRIPTION
- Updated project .env.example file to include database-related environment variables.
- Created a further .env.example file in Prisma directory (picked up by Prisma CLI).